### PR TITLE
Add: Paypay fix

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -16,7 +16,7 @@ class OrdersController < ApplicationController
   def index
     @orders = Order.all
     @order = Order.where(status: "incomplete").last
-    @transaction = params[:order][:merchantPaymentId]
+    # @transaction = params[:order][:merchantPaymentId]
   end
 
   def edit

--- a/lib/api_clients/pay_pay.rb
+++ b/lib/api_clients/pay_pay.rb
@@ -99,7 +99,8 @@ module PayPay
       OpenSSL::HMAC.digest(
         'sha256',
         api_secret,
-        [url, method, nonce, epoch, content_type, payload].join("\n")
+        # [url, method, nonce, epoch, content_type, payload].join("\n")
+        [url, method, nonce.to_s, epoch.to_s, content_type, payload].map(&:to_s).join("\n")
       )
     )
     ["hmac OPA-Auth:#{[api_key, hashed64, nonce, epoch, payload].join(":")}", content_type]


### PR DESCRIPTION
### Fix HMAC encoding issue in PayPay library

#### Description

This PR fixes the HMAC encoding issue in the PayPay library. The fix ensures that all elements are explicitly converted to strings before joining them, preventing implicit conversion errors.

#### Changes

- Updated the HMAC encoding logic to explicitly convert elements to strings.

#### Before

```ruby
hashed64 = Base64.strict_encode64(
  OpenSSL::HMAC.digest(
    'sha256',
    api_secret,
    [url, method, nonce, epoch, content_type, payload].join("\n")
  )
)