### PR TITLE
Edit: Event show data

### DIFF
--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -101,6 +101,13 @@
   height: 70vh;
 }
 
+.no-event-order-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 70vh;
+}
+
 .tooltip {
   position: relative;
   display: inline-block;

--- a/app/assets/stylesheets/components/_cards.scss
+++ b/app/assets/stylesheets/components/_cards.scss
@@ -93,6 +93,14 @@
   height: 70vh;
 }
 
+
+.no-event-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 70vh;
+}
+
 .tooltip {
   position: relative;
   display: inline-block;

--- a/app/assets/stylesheets/components/_dashboard_cards.scss
+++ b/app/assets/stylesheets/components/_dashboard_cards.scss
@@ -37,10 +37,22 @@
   justify-content: space-between;
 }
 
+#event-summary {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
 .overview h2 {
   text-align: left;
-  margin-top: 20px;
   font-size: 2rem;
+}
+
+#net-profit {
+  margin-top: 0;
+}
+
+.row span {
+  padding-left: 32%
 }
 
 
@@ -89,4 +101,10 @@
 
 .top-products-list strong {
   font-size: smaller;
+}
+
+
+.small-label {
+  font-size: 70%;
+  color: lightgrey;
 }

--- a/app/assets/stylesheets/components/_dashboard_cards.scss
+++ b/app/assets/stylesheets/components/_dashboard_cards.scss
@@ -51,7 +51,7 @@
   margin-top: 0;
 }
 
-.row span {
+#profit-header span {
   padding-left: 32%
 }
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -22,6 +22,11 @@ class EventsController < ApplicationController
     end
     @product_quantities.sort_by! {|pair| pair[1]}.reverse!
     @top_three = @product_quantities.take(3)
+
+    @net_profit = @total_earnings - @event.estimated_event_cost
+
+    @out_of_stock = @products.select { |product| product.quantity == 0 }
+    raise
   end
 
   def index

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -26,7 +26,6 @@ class EventsController < ApplicationController
     @net_profit = @total_earnings - @event.estimated_event_cost
 
     @out_of_stock = @products.select { |product| product.quantity == 0 }
-    raise
   end
 
   def index

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -15,7 +15,7 @@ class EventsController < ApplicationController
 
     # get top three selling products (by qty sold)
     # all products in event
-    @products = Product.joins(order_products: { order: :event }).where(events: { id: @event.id }).uniq
+    @products = current_user.products.joins(order_products: { order: :event }).where(events: { id: @event.id }).uniq
     # iterate over products
     @product_quantities = @products.map do |product|
       [product, product.order_products.sum {|op| op.product_quantity }]
@@ -29,7 +29,7 @@ class EventsController < ApplicationController
   end
 
   def index
-    @events = Event.all
+    @events = current_user.events
     @new_event = Event.new
     @order = Order.where(status: "incomplete").last
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   has_many :products
   has_many :order_products, through: :products
   has_many :orders, through: :order_products
+  has_many :events
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable

--- a/app/views/events/_dashboard.html.erb
+++ b/app/views/events/_dashboard.html.erb
@@ -1,0 +1,49 @@
+<div class="dashboard-cards">
+  <div class="dashboard-card overview justify-content-center" id="event-summary">
+    <div class="overview-earnings">
+      <div class="row">
+        <% if @net_profit.positive? %>
+          <span class="col"><i class="fa-solid fa-caret-up fa-3x" style="color: #63E6BE"></i></span>
+        <% else %>
+          <span class="col"><i class="fa-solid fa-caret-down fa-3x" style="color: #ec5555;"></i></span>
+        <% end %>
+        <h2 class="col" id="net-profit"><%= number_to_currency(@net_profit.abs, { unit: '¥', precision: 0 }) %></h2>
+      </div>
+      <p class="small-label">Net Profit</p>
+    </div>
+    <div class="overview-earnings">
+      <h3><%= number_to_currency(@total_earnings, { unit: '¥', precision: 0 }) %></h3>
+      <p class="small-label">earnings</p>
+      <hr>
+      <h3><%= number_to_currency(@event.estimated_event_cost, { unit: '¥', precision: 0 }) %></h3>
+      <p class="small-label">est. cost</p>
+    </div>
+  </div>
+  <div class="dashboard-card chart">
+    <p>Sales Breakdown by Day</p>
+    <%= render "day_chart" %>
+  </div>
+  <div class="dashboard-card top-products">
+    <p class="fw-bold">Your Top Selling Products are</p>
+    <ul class="top-products-list">
+      <% @top_three.each do |product| %>
+        <li>
+          <div class="d-flex justify-content-between">
+            <strong><%= product[0].name %></strong>
+            <small><%= product[1] %> units</small>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+  <%# <div class="dashboard-card chart"> %>
+  <%# <p>Sales Breakdown by Hour</p> %>
+  <%#= render "hour_chart" %>
+  <%# </div> %>
+</div>
+<div class="dashboard-card overview">
+  <div class="overview-products">
+    <p><strong><%= @products.count %></strong><br>
+      <small>products</small></p>
+  </div>
+</div>

--- a/app/views/events/_dashboard.html.erb
+++ b/app/views/events/_dashboard.html.erb
@@ -1,7 +1,7 @@
 <div class="dashboard-cards">
   <div class="dashboard-card overview justify-content-center" id="event-summary">
     <div class="overview-earnings">
-      <div class="row">
+      <div class="row" id="profit-header">
         <% if @net_profit.positive? %>
           <span class="col"><i class="fa-solid fa-caret-up fa-3x" style="color: #63E6BE"></i></span>
         <% else %>

--- a/app/views/events/_dashboard.html.erb
+++ b/app/views/events/_dashboard.html.erb
@@ -8,8 +8,8 @@
           <span class="col"><i class="fa-solid fa-caret-down fa-3x" style="color: #ec5555;"></i></span>
         <% end %>
         <h2 class="col" id="net-profit"><%= number_to_currency(@net_profit.abs, { unit: '¥', precision: 0 }) %></h2>
+        <p class="small-label">Net Profit</p>
       </div>
-      <p class="small-label">Net Profit</p>
     </div>
     <div class="overview-earnings">
       <h3><%= number_to_currency(@total_earnings, { unit: '¥', precision: 0 }) %></h3>
@@ -41,9 +41,9 @@
   <%#= render "hour_chart" %>
   <%# </div> %>
 </div>
-<div class="dashboard-card overview">
-  <div class="overview-products">
-    <p><strong><%= @products.count %></strong><br>
-      <small>products</small></p>
-  </div>
-</div>
+<%# <div class="dashboard-card overview"> %>
+<%# <div class="overview-products"> %>
+<%# <p><strong>= @products.count</strong><br> %>
+<%# <small>products</small></p> %>
+<%# </div> %>
+<%# </div> %>

--- a/app/views/events/_day_chart.html.erb
+++ b/app/views/events/_day_chart.html.erb
@@ -1,1 +1,1 @@
-<%= column_chart @orders.group_by_day(:updated_at).count, colors: ["#E2AB2D", "#3048EA","#9596FF", "#E67E22"] %>
+<%= column_chart @orders.group_by_day(:updated_at).sum(:total_price), colors: ["#E2AB2D", "#3048EA","#9596FF", "#E67E22"] %>

--- a/app/views/events/_hour_chart.html.erb
+++ b/app/views/events/_hour_chart.html.erb
@@ -1,1 +1,1 @@
-<%= line_chart @orders.group_by_hour(:updated_at).count, colors: ["#E2AB2D", "#3048EA","#9596FF", "#E67E22"] %>
+<%= line_chart @orders.group_by_hour(:updated_at).sum(:total_price), colors: ["#E2AB2D", "#3048EA","#9596FF", "#E67E22"] %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,17 +1,15 @@
-<div class="d-flex flex-column justify-content-center align-items-center vh-100">
-  <!-- See all Data button below -->
-  <%#   <div class="card-product mt-5"> %>
-  <%# <img src="https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/skateboard.jpg" /> %>
-  <%# <div class="card-product-infos">
+<h1 class="text-center my-3">Events Dashboard</h1>
+<% if current_user.events.any? %>
+  <div class="d-flex flex-column justify-content-center align-items-center vh-100">
+    <!-- See all Data button below -->
+    <%#   <div class="card-product mt-5"> %>
+    <%# <img src="https://raw.githubusercontent.com/lewagon/fullstack-images/master/uikit/skateboard.jpg" /> %>
+    <%# <div class="card-product-infos">
       <h2> See all Data</h2>
       <p>All Data :)</p>
     </div>
   </div> %>
-  <!-- Card iteration below -->
-  <div class="text-center my-2">
-    <h2>Events Dashboard</h2>
-  </div>
-  <% if current_user.events.any? %>
+    <!-- Card iteration below -->
     <%= render partial: 'events/events_cards' %>
     <!-- create button -->
     <div class="card-create">
@@ -21,9 +19,9 @@
     <%= render partial: "events/new_modal" %>
     <div>
     </div>
-  <% else %>
-    <div class="no-event-container">
-      <p class="no-event">There are no events yet. Let's create one! </p>
-    </div>
-  <% end %>
-</div>
+  </div>
+<% else %>
+  <div class="no-event-container">
+    <p class="no-event">There are no events yet. Let's create one! </p>
+  </div>
+<% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -11,13 +11,19 @@
   <div class="text-center my-2">
     <h2>Events Dashboard</h2>
   </div>
-  <%= render partial: 'events/events_cards' %>
-  <!-- create button -->
-  <div class="card-create">
-    <button type="button" class="fa-solid fa-circle-plus plus-btn-create" style="color: #E2AB2D" data-bs-toggle="modal" data-bs-target="#CreateEventModal">
-    </button>
-  </div>
-  <%= render partial: "events/new_modal" %>
-  <div>
-  </div>
+  <% if current_user.events.any? %>
+    <%= render partial: 'events/events_cards' %>
+    <!-- create button -->
+    <div class="card-create">
+      <button type="button" class="fa-solid fa-circle-plus plus-btn-create" style="color: #E2AB2D" data-bs-toggle="modal" data-bs-target="#CreateEventModal">
+      </button>
+    </div>
+    <%= render partial: "events/new_modal" %>
+    <div>
+    </div>
+  <% else %>
+    <div class="no-event-container">
+      <p class="no-event">There are no events yet. Let's create one! </p>
+    </div>
+  <% end %>
 </div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,57 +1,15 @@
-<h1 class="text-center my-3"><%= @event.event_name %></h1>
-<div class="dashboard-cards">
-  <p>2-11-13 Meguro, Meguro-ku, Tokyo<br>
-    〒153-0063<br>
-    <%= @event.start_date.strftime("%d-%b") %> to <%= @event.end_date.strftime("%d-%b") %>
-  </p>
-  <% if @event.orders.any? %>
-    <div class="dashboard-card overview justify-content-center">
-      <div class="overview-earnings">
-        <div class="row">
-          <% if @net_profit.positive? %>
-            <span class="col"><i class="fa-solid fa-caret-up fa-5x" style="color: #63E6BE;"></i></span>
-          <% else %>
-            <span class="col"><i class="fa-solid fa-caret-down fa-5x" style="color: #ec5555;"></i></span>
-          <% end %>
-          <h2 class="col"><%= number_to_currency(@net_profit.abs, { unit: '¥', precision: 0 }) %></h2>
-        </div>
-        <p class="text-center">Net Profit</p>
-      </div>
-    </div>
-    <div class="dashboard-card overview">
-      <div class="overview-earnings">
-        <h2><%= number_to_currency(@total_earnings, { unit: '¥', precision: 0 }) %></h2>
-        <p>earnings</p>
-      </div>
-      <div class="overview-products">
-        <p><strong><%= @products.count %></strong><br>
-          <small>products</small></p>
-      </div>
-    </div>
-    <div class="dashboard-card chart">
-      <p>Sales Breakdown by Day</p>
-      <%= render "day_chart" %>
-    </div>
-    <div class="dashboard-card top-products">
-      <p class="fw-bold">Your Top Selling Products are</p>
-      <ul class="top-products-list">
-        <% @top_three.each do |product| %>
-          <li>
-            <div class="d-flex justify-content-between">
-              <strong><%= product[0].name %></strong>
-              <small><%= product[1] %> units</small>
-            </div>
-          </li>
-        <% end %>
-      </ul>
-    </div>
-    <div class="dashboard-card chart">
-      <p>Sales Breakdown by Hour</p>
-      <%= render "hour_chart" %>
-    </div>
-  <% else %>
-    <div class="dashboard-card">
-      <p><small>You have no orders for this event yet.</small></p>
-    </div>
-  <% end %>
+<div class="text-center my-3">
+  <h1 class="text-center"><%= @event.event_name %></h1>
+  <p><small>📍2-11-13 Meguro, Meguro-ku, Tokyo<br>
+      〒153-0063<br>
+      <%= @event.start_date.strftime("%d-%b") %> to <%= @event.end_date.strftime("%d-%b") %>
+    </small></p>
 </div>
+<% if @event.orders.any? %>
+  <%= render "dashboard" %>
+<% else %>
+  <div class="no-event-order-container">
+    <p class="text-center">You have no orders for this event yet. <br>
+      Make it rain!</p>
+  </div>
+<% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,6 +4,19 @@
     <%= @event.start_date.strftime("%d-%b") %> to <%= @event.end_date.strftime("%d-%b") %>
   </p>
   <% if @event.orders.any? %>
+    <div class="dashboard-card overview justify-content-center">
+      <div class="overview-earnings">
+        <div class="row">
+          <% if @net_profit.positive? %>
+            <span class="col"><i class="fa-solid fa-caret-up fa-5x" style="color: #63E6BE;"></i></span>
+          <% else %>
+            <span class="col"><i class="fa-solid fa-caret-down fa-5x" style="color: #ec5555;"></i></span>
+          <% end %>
+          <h2 class="col"><%= number_to_currency(@net_profit.abs, { unit: '¥', precision: 0 }) %></h2>
+        </div>
+        <p class="text-center">Net Profit</p>
+      </div>
+    </div>
     <div class="dashboard-card overview">
       <div class="overview-earnings">
         <h2><%= number_to_currency(@total_earnings, { unit: '¥', precision: 0 }) %></h2>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,6 +1,7 @@
-<h1 class="text-center my-3">Lemonade Stand</h1>
+<h1 class="text-center my-3"><%= @event.event_name %></h1>
 <div class="dashboard-cards">
-  <p><%= @event.event_name %><br>
+  <p>2-11-13 Meguro, Meguro-ku, Tokyo<br>
+    〒153-0063<br>
     <%= @event.start_date.strftime("%d-%b") %> to <%= @event.end_date.strftime("%d-%b") %>
   </p>
   <% if @event.orders.any? %>


### PR DESCRIPTION
Som examples for the event show page below. 
- added a summary for the event 
- events index page calls current_user's events as well
- some things to add in the future: more data for the events show page, all user's orders dashboard, events need a location and photo 

<img width="262" alt="image" src="https://github.com/user-attachments/assets/05f493a9-876c-4048-82a1-2e15dcd8f1a6">
<img width="263" alt="image" src="https://github.com/user-attachments/assets/8b01a171-941c-415d-a05d-b9d364c0424e">
<img width="262" alt="image" src="https://github.com/user-attachments/assets/b476d100-5963-49b5-ab6f-c3b3f5b388ae">

