### PR TITLE
Update on Cart Modal: removed redundant form header

### DIFF
--- a/app/views/orders/_show_order.html.erb
+++ b/app/views/orders/_show_order.html.erb
@@ -1,4 +1,4 @@
-<h1 class="text-center my-3">Confirm Order</h1>
+<%# <h1 class="text-center my-3">Confirm Order</h1> %>
 <div class="orders">
   <%= render "orders/order_list", order: @order %>
   <%# calculate subtotal of current order %>


### PR DESCRIPTION
Removed the redundant Header on the Modal as the overall modal already has a title and the confirm order btn defines the action. 
Please see screenshots for before after: 
<img width="430" alt="Screenshot 2024-08-29 at 3 33 39 PM" src="https://github.com/user-attachments/assets/484a0ef3-9d81-497a-96ff-78fd90577ad3">
<img width="457" alt="Screenshot 2024-08-29 at 3 34 32 PM" src="https://github.com/user-attachments/assets/ea0d629c-e754-4b42-854b-5e4c62966771">
