### PR TITLE
Fixed: Cart modal confirm btn stays hovering on modal

### DIFF
--- a/app/assets/stylesheets/components/_modal-bottom.scss
+++ b/app/assets/stylesheets/components/_modal-bottom.scss
@@ -180,7 +180,7 @@
   flex-direction: column;
   justify-content: flex-start;
   transition: transform 0.3s ease-in-out;
-  max-height: 100vh;
+  max-height: 80vh; /* Limit modal height to 80% of the viewport */
   height: auto;
 }
 
@@ -194,7 +194,7 @@
   width: 100%;
   margin: 0;
   height: auto;
-  max-height: 100vh;
+  max-height: 80vh; /* Limit content height to 80% of the viewport */
   display: flex;
   flex-direction: column;
   overflow: hidden;
@@ -204,7 +204,7 @@
   flex-grow: 1;
   padding: 1rem;
   overflow-y: auto;
-  max-height: calc(100vh - 120px); /* Adjust based on header/footer height */
+  max-height: calc(80vh - 120px); /* Adjust based on header/footer height */
 }
 
 .fixed-footer {

--- a/app/assets/stylesheets/components/_modal-bottom.scss
+++ b/app/assets/stylesheets/components/_modal-bottom.scss
@@ -167,3 +167,52 @@
   flex-shrink: 0;
   padding: 1rem;
 }
+
+/* Fixed Footer Modal Classes used for cart modal */
+.fixed-footer-modal .fixed-footer-dialog {
+  position: fixed !important;
+  bottom: 0;
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  max-width: none;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  transition: transform 0.3s ease-in-out;
+  max-height: 100vh;
+  height: auto;
+}
+
+.fixed-footer-modal.show .fixed-footer-dialog {
+  transform: translateY(0);
+}
+
+.fixed-footer-content {
+  border-top-left-radius: 40px;
+  border-top-right-radius: 40px;
+  width: 100%;
+  margin: 0;
+  height: auto;
+  max-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.fixed-footer-body {
+  flex-grow: 1;
+  padding: 1rem;
+  overflow-y: auto;
+  max-height: calc(100vh - 120px); /* Adjust based on header/footer height */
+}
+
+.fixed-footer {
+  flex-shrink: 0;
+  padding: 1rem;
+  position: sticky;
+  bottom: 0;
+  background-color: white; /* Ensure the button area is always visible */
+  z-index: 10;
+  border-top: 1px solid #ddd;
+}

--- a/app/views/orders/_cart_modal.html.erb
+++ b/app/views/orders/_cart_modal.html.erb
@@ -1,18 +1,20 @@
 <div data-controller="cart">
-  <div data-cart-target="showProductOrder" >
+  <div data-cart-target="showProductOrder">
     <div id="show_order">
-      <div class="modal fade slide-up-modal" id="CartModal" tabindex="-1" aria-labelledby="CartModalLabel" aria-hidden="true">
-        <div class="modal-dialog modal-dialog-slide-up modal-dialog-bottom">
-          <div class="modal-content">
+      <div class="modal fade slide-up-modal fixed-footer-modal" id="CartModal" tabindex="-1" aria-labelledby="CartModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-slide-up modal-dialog-bottom fixed-footer-dialog">
+          <div class="modal-content fixed-footer-content">
             <div class="modal-header">
               <h1 class="modal-title fs-5" id="CartModalLabel">Cart Overview</h1>
               <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
             </div>
-            <div class="modal-body scrollable-modal">
+            <div class="modal-body fixed-footer-body">
               <%= render "orders/show_order", order: @order %>
             </div>
-            <div class="d-flex justify-content-center">
-              <%= link_to "Confirm Order", order_path(@order), class:"btn btn-primary my-2", style:"color:white" %>
+            <div class="fixed-footer">
+              <div class="d-flex justify-content-center">
+                <%= link_to "Confirm Order", order_path(@order), class:"btn btn-primary my-2", style:"color:white" %>
+              </div>
             </div>
             <div class="modal-footer">
               <%# <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button> %>


### PR DESCRIPTION
Fixed the issue where the confirm cart button would scroll below the users view. 
Button now remains fixed on bottom of the modal, independent of scroll. 
Check video of CX


https://github.com/user-attachments/assets/5bb59495-d803-4db0-ba73-5a57038ff182


