### PR TITLE
Fixing order to event assignement

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -42,15 +42,16 @@ class OrdersController < ApplicationController
 
   def update
     @order = Order.find(params[:id])
-    @last_complete_order = Order.find(params[:id].to_i - 1)
+    # @last_complete_order = Order.find(params[:id].to_i - 1)
     # @event = Event.where('start_date >= ? AND end_date <= ?', @last_complete_order.updated_at.beginning_of_day, @last_complete_order.updated_at.end_of_day)[0]
     @event = Event.where('start_date <= ? AND end_date >= ?', @order.updated_at, @order.updated_at).first
-    @last_complete_order.update(event: @event)
+    # @last_complete_order.update(event: @event)
 
     @order.order_products.each do |op|
       if op.product_quantity <= 0
         op.destroy
       end
+    @order.event = @event
     @order.save
     end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,8 +12,8 @@ class Event < ApplicationRecord
       order_updated_date = order.updated_at
       if order.updated_at >= self.start_date.beginning_of_day && order.updated_at <= self.end_date.end_of_day
         order.update(event: self)
-      elsif order.event.present?
-        order.update(updated_at: order_updated_date)
+      # elsif order.event.present?
+      #   order.update(updated_at: order_updated_date)
       else
         order.update(event: nil)
         order.update(updated_at: order_updated_date)


### PR DESCRIPTION
These changes should fix the issues where changing event dates does not un/assign orders to an event and the issue where new orders(after the initial one) are not assigned to existing events. 

Have a look and let me know your thoughts. 

https://github.com/user-attachments/assets/378f2dbb-a72c-4187-a52c-fb161ba5fe62

